### PR TITLE
Handle more gracefully the case when the number of reachable attractors with proba>0 is zero

### DIFF
--- a/mpbn/simulation.py
+++ b/mpbn/simulation.py
@@ -183,25 +183,22 @@ def is_subhypercube(a, b):
     return H.issubset(G) and \
             not [i for i in set(x).difference(G) if x[i] != y[i]]
 
-def sample_reachable_attractor(f, mem, x, A, depth, W, refresh_rate=10, emit=None):
-    if not isinstance(f, MPBNSim): f = MPBNSim(f)
+def sample_reachable_attractor(f, mem, x, A, depth, W, refresh_rate=10):
     I = set(f)
     n = len(f)
     def filter_reachable_attractors(A, x):
-        H = spread(f, x, I, n)
+        H = mpbn_sim.spread(f, x, I, n) 
         return [(ia,a) for (ia,a) in A if is_subhypercube(a, (x,H))]
     k = 1
     x = x.copy()
     A = filter_reachable_attractors(A, x)
     while len(A) > 1:
-        if emit is not None:
-            emit(x)
         if not step(f, mem, x, depth, W):
             k = 0
         if k % refresh_rate == 0:
             A = filter_reachable_attractors(A, x)
         k += 1
-    return A[0][0]
+    return None if (len(A)==0) else A[0][0]
 
 def sample_trace(f, mem, x, A, depth, W):
     if not isinstance(f, MPBNSim): f = MPBNSim(f)
@@ -257,6 +254,8 @@ def estimate_reachable_attractors_probabilities(f, x, A, nb_sims, depth, W):
     C = {ia: 0 for (ia,_) in A}
     for _ in tqdm(range(nb_sims)):
         ia = sample_reachable_attractor(f, mem, x, A, depth, W)
+        if (ia is None):
+        	continue
         C[ia] += 1
     for ia, _ in A:
         C[ia] = (C[ia]*100) / nb_sims

--- a/mpbn/simulation.py
+++ b/mpbn/simulation.py
@@ -183,16 +183,19 @@ def is_subhypercube(a, b):
     return H.issubset(G) and \
             not [i for i in set(x).difference(G) if x[i] != y[i]]
 
-def sample_reachable_attractor(f, mem, x, A, depth, W, refresh_rate=10):
+def sample_reachable_attractor(f, mem, x, A, depth, W, refresh_rate=10, emit=None):
+    if not isinstance(f, MPBNSim): f = MPBNSim(f)
     I = set(f)
     n = len(f)
     def filter_reachable_attractors(A, x):
-        H = mpbn_sim.spread(f, x, I, n) 
+        H = spread(f, x, I, n) 
         return [(ia,a) for (ia,a) in A if is_subhypercube(a, (x,H))]
     k = 1
     x = x.copy()
     A = filter_reachable_attractors(A, x)
     while len(A) > 1:
+        if emit is not None:
+            emit(x)
         if not step(f, mem, x, depth, W):
             k = 0
         if k % refresh_rate == 0:


### PR DESCRIPTION
Hello,

I recently encountered the case where I tried to generate reachable attractors and their associated probabilities for my network, and actually no attractor with probability>0 was returned (depending on the initial condition and the parameter limit in the computation of reachable attractors: the network is not mutated). In the previous version of the code, this raises an exception in the return instruction of function sample_reachable_attractor, whereas I would prefer to check the number of attractors and handle the issue myself. 

Cheers,